### PR TITLE
chore(package): update react-redux to version 6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-plotly.js": "^2.2.0",
-    "react-redux": "^6.0.0",
+    "react-redux": "^6.0.1",
     "redux": "^4.0.0",
     "redux-logger": "^3.0.6",
     "lab-gui-websocket": "^2.0.0"


### PR DESCRIPTION
Upgrade to "react-redux": "6.0.1" should work now, since the error was caused by npm not being able to download that version.